### PR TITLE
audio synchronization fix

### DIFF
--- a/core/youtubeservice.py
+++ b/core/youtubeservice.py
@@ -118,7 +118,7 @@ def synchronize_audios(videos, working_dir):
             content_details_json = cloud_video.get(CONTENT_DETAILS)
             audio_id = content_details_json.get(VIDEO_ID)
 
-            audio_title_full = util.generate_video_title(audio_title, audio_id)
+            audio_title_full = util.generate_video_title(audio_title, audio_id, clean=True)
             if audio_title_full not in local_audios:
                 audios_to_download.append(cloud_video)
 


### PR DESCRIPTION
Fix synchronization functionality for videos with 'special_characters' in title (sync skips them and reloads every time), see `core/util.py`